### PR TITLE
fix: display CJK folder names in game browser

### DIFF
--- a/src/onsyuri/GameBrowser.h
+++ b/src/onsyuri/GameBrowser.h
@@ -95,6 +95,8 @@ private:
     bool loadGameCover(GameInfo& game);
     bool loadCoverTexture(GameInfo& game);
 
+    std::string convertToUTF8(const char* filename);
+
 private:
     SDL_Window* window_;
     SDL_Renderer* renderer_;


### PR DESCRIPTION
## Summary
- convert non-UTF8 folder names to UTF-8 using GBK/SJIS fallbacks
- keep UTF-8 names unchanged and center titles with UTF-8 sizing
- ensure CJK game titles render above covers correctly

## Testing
- make -f Makefile.switch -j4
